### PR TITLE
Upgrade build system to pin lunet v0.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 *.dll
 *.dylib
 
+# Lunet dependency (cloned at build time)
+lunet/
+
 # Temporary files
 .tmp/
 *.sqlite3

--- a/README.md
+++ b/README.md
@@ -48,12 +48,11 @@ cd lunet-realworld-linux-amd64
 ### Option 2: Build from Source
 
 ```bash
-# 1. Clone repositories
-git clone https://github.com/lua-lunet/lunet.git
+# 1. Clone this repository
 git clone https://github.com/lua-lunet/lunet-realworld-example-app.git
 cd lunet-realworld-example-app
 
-# 2. Build lunet and SQLite driver
+# 2. Build lunet (cloned automatically at v0.1.2)
 make build
 
 # 3. Start the server


### PR DESCRIPTION
## Summary

Upgrades the build system to follow the canonical integration pattern from lunet's XMAKE_INTEGRATION.md documentation.

## Changes

- Clone lunet v0.1.2 at build time (self-contained, no sibling directory assumption)
- Use xmake flags per upstream docs: --lunet_trace=n --lunet_verbose_trace=n
- Update .gitignore to exclude lunet/ subdirectory
- Update README.md build instructions (no separate lunet clone needed)
- Badge already correct (v0.1.2 per BADGES.md format)

## Testing

- Build completes successfully with lunet v0.1.2
- API tests pass (14/14)
- Browser UI loads correctly

## Related

Fixes #6
