### PR TITLE
Pull request issues

### DIFF
--- a/scripts/install-vendor.lua
+++ b/scripts/install-vendor.lua
@@ -92,7 +92,7 @@ local function sha256_bytes(msg)
     end
 
     local function to_hex(x)
-        return string.format("%08x", x)
+        return bit.tohex(x, 8)
     end
 
     return (to_hex(H0) .. to_hex(H1) .. to_hex(H2) .. to_hex(H3) .. to_hex(H4) .. to_hex(H5) .. to_hex(H6) .. to_hex(H7))
@@ -122,7 +122,8 @@ local function ensure_dir(path)
 end
 
 local function download_file(url, dest_path, timeout_seconds)
-    local cmd = string.format("curl -fsSL --max-time %d -o '%s' '%s'", timeout_seconds or 30, dest_path, url)
+    local quote = is_windows() and '"' or "'"
+    local cmd = string.format("curl -fsSL --max-time %d -o %s%s%s %s%s%s", timeout_seconds or 30, quote, dest_path, quote, quote, url, quote)
     local handle = io.popen(cmd .. " 2>&1")
     local output = handle:read("*a")
     local success = handle:close()


### PR DESCRIPTION
Fix SHA256 `to_hex` portability and Windows `download_file` quoting.

The SHA256 `to_hex` function was unsafe for negative 32-bit values from `bit.tobit` on 64-bit systems, leading to corrupted hashes. `bit.tohex` is now used for correct, portable hex output. Additionally, `download_file` now uses platform-aware quoting (double quotes on Windows, single quotes on Unix) to prevent `curl` command failures on Windows where single quotes are invalid.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e4850187-4d3f-4cec-b138-abc1e14f3093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4850187-4d3f-4cec-b138-abc1e14f3093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

